### PR TITLE
Returns a disabled metrics collector instead of None collector

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,7 +10,7 @@ RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSI
     && rm dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz
 
 COPY requirements.* ./
-RUN pip install --no-cache-dir --upgrade -r requirements.txt -r requirements.test.txt
+RUN pip install --no-cache-dir --upgrade -r requirements.txt
 
 COPY . .
 RUN set -x && pip install .

--- a/src/microengineutils/datadog.py
+++ b/src/microengineutils/datadog.py
@@ -14,11 +14,11 @@ def configure_metrics(datadog_api_key, datadog_app_key, engine_name, os_type, po
                 f'engine_name:{engine_name}',
                 f'pod_name:{source}',
                 f'os:{os_type}',
-                'testing' if poly_work == 'local' else ''
+                'testing' if poly_work == 'local' else '',
             ]
         options = {
             'api_key': datadog_api_key,
-            'app_key': datadog_app_key
+            'app_key': datadog_app_key,
         }
 
         initialize(**options)

--- a/src/microengineutils/datadog.py
+++ b/src/microengineutils/datadog.py
@@ -13,7 +13,7 @@ def configure_metrics(datadog_api_key,
     Initialize Datadog metric collectors when the datadog env keys are set
     :return: datadog.ThreadStats
     """
-    if datadog_api_key is not None or datadog_app_key is not None:
+    if datadog_api_key or datadog_app_key:
         if tags is None:
             tags = [
                 f'poly_work:{poly_work}',

--- a/src/microengineutils/datadog.py
+++ b/src/microengineutils/datadog.py
@@ -1,12 +1,18 @@
 from datadog import initialize, ThreadStats
 
 
-def configure_metrics(datadog_api_key, datadog_app_key, engine_name, os_type, poly_work, source, tags=None):
+def configure_metrics(datadog_api_key,
+                      datadog_app_key,
+                      engine_name,
+                      os_type,
+                      poly_work,
+                      source,
+                      tags=None,
+                      disabled=False) -> ThreadStats:
     """
-            Initialize Datadog metric collectors when the datadog env keys are set
-            :return:
-            """
-
+    Initialize Datadog metric collectors when the datadog env keys are set
+    :return: datadog.ThreadStats
+    """
     if datadog_api_key is not None or datadog_app_key is not None:
         if tags is None:
             tags = [
@@ -24,7 +30,8 @@ def configure_metrics(datadog_api_key, datadog_app_key, engine_name, os_type, po
         initialize(**options)
 
         metrics_collector = ThreadStats(namespace='polyswarm', constant_tags=tags)
-        metrics_collector.start()
-        return metrics_collector
     else:
-        return None
+        disabled = True
+
+    metrics_collector.start(disabled=disabled)
+    return metrics_collector


### PR DESCRIPTION
When no collector can be created from the input of `configure_metrics()`, return a dumb one instead of returning None.

This allows the client code to be the same for working and disabled metrics collection.