### PR TITLE
Fixes e2e when running on pyproject.toml w/ old setuptools

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,7 +10,7 @@ stages:
 
 default:
   before_script:
-    - pip install -q --upgrade pip
+    - pip install -q --upgrade pip setuptools
     - pip install -q $END_TO_END_LIB@$CI_COMMIT_REF_NAME || pip install -q $END_TO_END_LIB
     - e2e init
 


### PR DESCRIPTION
`e2e release` worked on `dev-pypi` job because `setuptools` got updated because bump-my-version. On `release-pypi` job it was not updated, resulting in error when running `e2e release`. 